### PR TITLE
fix: 优化飞牛 App 内置浏览器无法保存密码的问题

### DIFF
--- a/internal/controllers/base.go
+++ b/internal/controllers/base.go
@@ -188,7 +188,7 @@ func Cors() gin.HandlerFunc {
 			//              允许跨域设置                                                                                                      可以返回其他子段
 			c.Header("Access-Control-Expose-Headers", "Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers,Cache-Control,Content-Language,Content-Type,Expires,Last-Modified,Pragma,FooBar") // 跨域关键设置 让浏览器可以解析
 			c.Header("Access-Control-Max-Age", "172800")                                                                                                                                                           // 缓存请求信息 单位为秒
-			c.Header("Access-Control-Allow-Credentials", "false")                                                                                                                                                  //  跨域请求是否需要带cookie信息 默认设置为true
+			c.Header("Access-Control-Allow-Credentials", "true")                                                                                                                                                  //  跨域请求是否需要带cookie信息 默认设置为true
 			c.Set("content-type", "application/json")                                                                                                                                                              // 设置返回格式是json
 		}
 

--- a/internal/controllers/users.go
+++ b/internal/controllers/users.go
@@ -12,8 +12,9 @@ import (
 )
 
 type LoginRequest struct {
-	Username string `json:"username" form:"username"`
-	Password string `json:"password" form:"password"`
+	Username   string `json:"username" form:"username"`
+	Password   string `json:"password" form:"password"`
+	RememberMe bool   `json:"remember_me" form:"remember_me"`
 }
 
 var LoginedUser *models.User = nil
@@ -64,6 +65,23 @@ func LoginAction(c *gin.Context) {
 		return
 	}
 	LoginedUser = user
+
+	// 设置Cookie以支持飞牛App内置浏览器
+	maxAge := 3600 // 默认1小时
+	if req.RememberMe {
+		maxAge = 86400 * 7 // 7天
+	}
+	cookie := &http.Cookie{
+		Name:     "auth_token",
+		Value:    tokenString,
+		Path:     "/",
+		MaxAge:   maxAge,
+		HttpOnly: false, // 允许前端读取
+		Secure:   false, // 允许HTTP
+		SameSite: http.SameSiteLaxMode,
+	}
+	http.SetCookie(c.Writer, cookie)
+
 	res := make(map[string]interface{})
 	u := make(map[string]string)
 	u["id"] = fmt.Sprintf("%d", user.ID)


### PR DESCRIPTION
## 问题描述
飞牛 App 内置浏览器无法保存密码，用户每次需要手动输入登录凭据，影响用户体验。

## 技术方案
**Cookie + localStorage 双重存储方案**

### 后端改动
1. ✅ 登录接口返回 token 时同时设置 Cookie
2. ✅ Cookie 配置：
   - Name: auth_token
   - MaxAge: 3600（默认）或 604800（记住我）
   - HttpOnly: false（允许前端读取）
   - Secure: false（允许 HTTP）
   - SameSite: Lax
3. ✅ CORS 配置 Access-Control-Allow-Credentials=true

### 前端改动
对应的前端仓库 PR: https://github.com/qicfan/q115-strm-frontend/pull/new/feature/issue-124-fennas-password-save

## 测试步骤
1. 在飞牛 App 内置浏览器中访问应用
2. 输入用户名密码登录
3. 关闭浏览器重新打开
4. 验证是否保持登录状态

## 关联 Issue
Fixes #124