### PR TITLE
Issue #122: 修复多次播放退出后显示5XX server error

### DIFF
--- a/internal/controllers/open115.go
+++ b/internal/controllers/open115.go
@@ -136,6 +136,38 @@ func GetFileDetail(c *gin.Context) {
 
 var keyLock KeyLockWithTimeout
 
+// checkURLValidity 使用HEAD请求检查URL是否有效
+// 返回true表示URL有效（2xx状态码），false表示URL已失效
+func checkURLValidity(urlStr string) bool {
+	client := &http.Client{
+		Timeout: 3 * time.Second, // 3秒超时
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// 不跟随重定向，只检查第一次响应
+			return http.ErrUseLastResponse
+		},
+	}
+
+	req, err := http.NewRequest("HEAD", urlStr, nil)
+	if err != nil {
+		helpers.AppLogger.Warnf("创建HEAD请求失败: %v", err)
+		return false
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		helpers.AppLogger.Warnf("HEAD请求失败: %v", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	// 检查状态码是否为2xx
+	isValid := resp.StatusCode >= 200 && resp.StatusCode < 300
+	if !isValid {
+		helpers.AppLogger.Warnf("URL已失效，状态码: %d, URL: %s", resp.StatusCode, urlStr)
+	}
+	return isValid
+}
+
 // 查询并302跳转到115文件直链
 // 请求下载链接的user-agent必须跟访问下载链接的user-agent相同
 func Get115FileUrl(c *gin.Context) {
@@ -185,6 +217,20 @@ func Get115FileUrl(c *gin.Context) {
 			db.Cache.Set(cacheKey, []byte(cachedUrl), 1800)
 		} else {
 			helpers.AppLogger.Infof("从缓存中查询到115下载链接: pickcode=%s, ua=%s => %s", req.PickCode, ua, cachedUrl)
+			// 检查缓存链接是否有效
+			if !checkURLValidity(cachedUrl) {
+				helpers.AppLogger.Warnf("缓存链接已失效，删除缓存并重新获取: pickcode=%s, ua=%s", req.PickCode, ua)
+				db.Cache.Delete(cacheKey)
+				// 重新获取链接
+				cachedUrl = client.GetDownloadUrl(context.Background(), req.PickCode, ua, true)
+				if cachedUrl == "" {
+					c.JSON(http.StatusOK, APIResponse[any]{Code: BadRequest, Message: "获取115下载链接失败", Data: nil})
+					return
+				}
+				helpers.AppLogger.Infof("重新获取到115下载链接: pickcode=%s, ua=%s => %s", req.PickCode, ua, cachedUrl)
+				// 缓存半小时
+				db.Cache.Set(cacheKey, []byte(cachedUrl), 1800)
+			}
 		}
 		if req.Force == 0 {
 			if models.SettingsGlobal.LocalProxy == 1 {
@@ -278,6 +324,20 @@ func Get115UrlByPickCode(c *gin.Context) {
 			db.Cache.Set(cacheKey, []byte(cachedUrl), 3000)
 		} else {
 			helpers.AppLogger.Infof("从缓存中查询到115下载链接: pickcode=%s, ua=%s => %s", pickCode, ua, cachedUrl)
+			// 检查缓存链接是否有效
+			if !checkURLValidity(cachedUrl) {
+				helpers.AppLogger.Warnf("缓存链接已失效，删除缓存并重新获取: pickcode=%s, ua=%s", pickCode, ua)
+				db.Cache.Delete(cacheKey)
+				// 重新获取链接
+				cachedUrl = client.GetDownloadUrl(context.Background(), pickCode, ua, true)
+				if cachedUrl == "" {
+					c.JSON(http.StatusOK, APIResponse[any]{Code: BadRequest, Message: "获取115下载链接失败", Data: nil})
+					return
+				}
+				helpers.AppLogger.Infof("重新获取到115下载链接: pickcode=%s, ua=%s => %s", pickCode, ua, cachedUrl)
+				// 缓存50分钟
+				db.Cache.Set(cacheKey, []byte(cachedUrl), 3000)
+			}
 		}
 		if req.Force == 0 {
 			if models.SettingsGlobal.LocalProxy == 1 {


### PR DESCRIPTION
## 功能说明

解决多次播放后退出时出现 "server returned 5XX server error replay" 的问题，提升多播放器并发播放的用户体验。

## 问题根因

当前系统存在 115 直链缓存失效问题：
1. 多个播放器通过不同的 UA 请求获取 115 直链
2. 同一个资源的 115 直链有数量限制，多个播放器先后请求会导致老链接失效
3. 当前缓存逻辑未检测链接失效，仍返回失效链接给播放器
4. 播放器访问失效链接时返回 5XX 错误

## 解决方案

**缓存 + HEAD 失效检测**：从缓存获取链接后，执行 HEAD 请求检查，如不为 2xx 则删除缓存并重新获取。

## 改动内容

### 1. 实现 HEAD 检测函数
- 文件: `internal/controllers/open115.go`
- 新增 `checkURLValidity` 函数
- HEAD 请求超时设置为 3 秒
- 不跟随重定向，只检查第一次响应
- 返回 true 表示有效（2xx），false 表示失效

### 2. 修改 Get115FileUrl 函数
- 在缓存命中时，先检查链接有效性
- 如果失效，删除缓存并重新获取
- 添加详细日志记录

### 3. 修改 Get115UrlByPickCode 函数
- 在缓存命中时，先检查链接有效性
- 如果失效，删除缓存并重新获取
- 添加详细日志记录

## 功能特性

- ✅ 自动检测缓存链接有效性
- ✅ 检测到失效时自动重新获取
- ✅ HEAD 请求超时 3 秒，不影响播放速度
- ✅ 只检测缓存命中情况，不影响首次获取
- ✅ 完善的异常处理和日志记录

## 测试场景

### 场景 1：多播放器并发播放
- **操作**：在电视上播放，同时在手机上播放同一部电影
- **预期**：两个播放器都能正常播放，不会出现 5XX 错误

### 场景 2：多次播放同一资源
- **操作**：播放一部电影，退出后再次播放
- **预期**：能够正常重新播放，不会出现 5XX 错误

## 性能影响

- 缓存命中时增加 HEAD 请求检测（≤3秒）
- 链接有效时：增加约 100-500ms 延迟
- 链接失效时：自动重新获取，避免 5XX 错误
- 不影响首次获取链接的速度

## 关联Issue

Closes #122