### PR TITLE
Issue #143: 修复Telegram通知入库季集重复显示

### DIFF
--- a/internal/controllers/emby.go
+++ b/internal/controllers/emby.go
@@ -600,6 +600,19 @@ func sendDeletedSeriesNotification(seriesId string, seriesName string, seasons m
 	}
 }
 
+// removeDuplicates 去除剧集数组中的重复集数
+func removeDuplicates(episodes []int) []int {
+	seen := make(map[int]struct{})
+	result := make([]int, 0, len(episodes))
+	for _, ep := range episodes {
+		if _, exists := seen[ep]; !exists {
+			seen[ep] = struct{}{}
+			result = append(result, ep)
+		}
+	}
+	return result
+}
+
 func formatSeasonEpisodes(seasons map[int][]int) string {
 	if len(seasons) == 0 {
 		return ""
@@ -617,6 +630,10 @@ func formatSeasonEpisodes(seasons map[int][]int) string {
 		if len(episodes) == 0 {
 			continue
 		}
+
+		// 去重处理，避免同一集多次触发事件导致重复显示
+		episodes = removeDuplicates(episodes)
+
 		sort.Ints(episodes)
 		seasonStr := fmt.Sprintf("S%d", seasonNumber)
 


### PR DESCRIPTION
## 问题描述

当 Emby 触发 `library.new` 事件时，QMediaSync 的 Telegram 入库通知中，入库季集显示重复。

### 问题现象
**异常显示**：
```
📺 入库季集: S1E1, E1 - E2, E2 - E3, E3 - E4...E29 - E30
```

**正常应该显示**：
```
📺 入库季集: S1E1-E30
```

## 根本原因

当同一剧集多次触发 Emby 的 `library.new` 事件时，同一集会被多次添加到缓冲区数组中，例如：
```go
// episodes 数组变成：
[1, 1, 2, 2, 3, 3, 4, 4, ... 30, 30]
```

格式化时会输出重复的集数范围，导致通知显示异常。

## 解决方案

在 `formatSeasonEpisodes` 函数中，对 episodes 数组进行去重处理。

## 改动内容

### 1. 添加 removeDuplicates 辅助函数
```go
// removeDuplicates 去除剧集数组中的重复集数
func removeDuplicates(episodes []int) []int {
	seen := make(map[int]struct{})
	result := make([]int, 0, len(episodes))
	for _, ep := range episodes {
		if _, exists := seen[ep]; !exists {
			seen[ep] = struct{}{}
			result = append(result, ep)
		}
	}
	return result
}
```

### 2. 修改 formatSeasonEpisodes 函数
在排序前先进行去重处理：
```go
// 去重处理，避免同一集多次触发事件导致重复显示
episodes = removeDuplicates(episodes)
```

## 测试场景

### 场景 1：同一剧集多次触发 library.new 事件
- **操作**：同步大量剧集到 Emby，同一集多次触发事件
- **预期**：通知中的集数显示正确，无重复
- **示例**：S1E1-E30（而不是 S1E1, E1 - E2, E2 - E3...）

### 场景 2：连续集数范围合并
- **操作**：入库 E1, E2, E3, E4, E5
- **预期**：显示 S1E1-E5
- **不影响**：现有的连续集数范围合并逻辑

## 影响范围

- 修改文件：`internal/controllers/emby.go`
- 影响功能：Telegram 入库通知
- 不影响其他功能

## 关联Issue

Closes #143