### PR TITLE
Issue #161: 整理模板增加en_title、videoCodec、audioCodec、releaseGroup、resourceType、original_name变量

### DIFF
--- a/internal/helpers/extract.go
+++ b/internal/helpers/extract.go
@@ -49,11 +49,13 @@ var preExclucdePatterns = []string{
 }
 
 type MediaInfo struct {
-	Name    string `json:"name"`
-	Year    int    `json:"year"`
-	Season  int    `json:"season"`
-	Episode int    `json:"episode"`
-	TmdbId  int64  `json:"tmdbid"`
+	Name         string `json:"name"`
+	Year         int    `json:"year"`
+	Season       int    `json:"season"`
+	Episode      int    `json:"episode"`
+	TmdbId       int64  `json:"tmdbid"`
+	ReleaseGroup string `json:"release_group"` // 发布组
+	ResourceType string `json:"resource_type"` // 资源类型
 }
 
 func ExtractTmdbId(name string) int64 {
@@ -189,6 +191,11 @@ func ExtractMediaInfoRe(name string, isMovie bool, seEp bool, videoExt []string,
 	// 用分隔符连接newNames
 	name = strings.Join(newNames, maxDelimiter)
 	// fmt.Printf("连接后文件名: %s\n", name)
+
+	// 提取发布组和资源类型（在清理之前）
+	info.ReleaseGroup = ExtractReleaseGroup(name)
+	info.ResourceType = ExtractResourceType(name)
+
 	// 移除结尾的发布组
 	name = removeTitleGroup(name)
 	name = cleanFilename(name)
@@ -404,6 +411,77 @@ func cleanFilename(name string) string {
 	// }
 	// fmt.Printf("去掉下划线后的文件名: %s\n", name)
 	return strings.TrimSpace(name)
+}
+
+// ExtractReleaseGroup 提取发布组名称
+func ExtractReleaseGroup(filename string) string {
+	// 常见的发布组模式
+	releaseGroupPatterns := []string{
+		`MTeam$`, `TPTV$`, `SupaHacka$`, `c0kE$`, `HONE$`, `HDZ$`, `CHD$`,
+		`CSWEB$`, `BLoz$`, `ADE$`, `TMT$`, `HDS$`, `HDH$`, `INCUBO$`,
+		`GMA$`, `NoGrp$`, `MainFrame$`, `MNHD-FRDS$`, `SharpHD$`, `UBits$`,
+		`ZmWeb$`, `MKu$`, `CMCTV$`, `ADWeb$`, `UBWEB$`, `Panda$`, `iFPD$`,
+		`LWRTD$`, `ZTR$`, `CHDWEB$`, `PtBM$`, `WiKi$`, `BONE$`, `HHWEB$`,
+		`MWeb$`, "SPWEB$", "DREAMHD$",
+		`PTer$`, `MWeb$`, `NoGroup$`, `CMCT$`, `HDSky$`, `Hero$`, `HDSky$`,
+		`CHDBits$`, `HDHome$`, `HDSpace$`, `QuickIO$`, `NUKEHD$`, `WEBLE$`,
+		`112114119$`,
+		`CtrlHD$`, `FraMeSToR$`, `ExKinoRay$`, `HDSKY$`,
+	}
+
+	// 提取发布组
+	for _, pattern := range releaseGroupPatterns {
+		re := regexp.MustCompile(`(?i)(\-[\p{han}\a-z|0-9]+)?(\-|@)?` + pattern)
+		matches := re.FindStringSubmatch(filename)
+		if len(matches) > 0 {
+			// 提取发布组名称（去除前缀和后缀）
+			releaseGroup := strings.TrimSuffix(matches[0], "-")
+			releaseGroup = strings.TrimPrefix(releaseGroup, "-")
+			releaseGroup = strings.TrimSuffix(releaseGroup, "@")
+			releaseGroup = strings.TrimSpace(releaseGroup)
+			if releaseGroup != "" {
+				return releaseGroup
+			}
+		}
+	}
+
+	// 尝试匹配通用的发布组模式（文件名末尾的横杠+字母数字组合）
+	re := regexp.MustCompile(`-(\w{2,})$`)
+	matches := re.FindStringSubmatch(filename)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+
+	return ""
+}
+
+// ExtractResourceType 提取资源类型
+func ExtractResourceType(filename string) string {
+	// 资源类型识别规则（按优先级排序）
+	resourceTypePatterns := []struct {
+		pattern string
+		typeStr string
+	}{
+		{`(?i)BluRay\.?Remux`, "BluRay Remux"},
+		{`(?i)Remux`, "Remux"},
+		{`(?i)(Blu.?Ray|Blue.?Ray|BDRip)`, "BluRay"},
+		{`(?i)(WEB.?DL|WEBDL|Netflix|Amazon|Disney\+|Hulu)`, "WEB-DL"},
+		{`(?i)(WEBRip|WEB-Rip)`, "WEBRip"},
+		{`(?i)HDTV`, "HDTV"},
+		{`(?i)(TVRip|TV-Rip)`, "TVRip"},
+		{`(?i)(DVD5|DVD9|DVDRip|DVD-Rip)`, "DVD"},
+		{`(?i)UHD`, "UHD"},
+		{`(?i)4K`, "4K"},
+	}
+
+	for _, rp := range resourceTypePatterns {
+		re := regexp.MustCompile(rp.pattern)
+		if re.MatchString(filename) {
+			return rp.typeStr
+		}
+	}
+
+	return ""
 }
 
 func removeTitleGroup(filename string) string {

--- a/internal/models/migrator.go
+++ b/internal/models/migrator.go
@@ -17,7 +17,7 @@ type Migrator struct {
 	VersionCode int `json:"version_code"` // 版本号
 }
 
-var MaxVersionCode = 33
+var MaxVersionCode = 34
 var AllTables = []any{
 	BackupConfig{}, BackupRecord{},
 	ApiKey{}, Settings{}, Sync{}, User{}, Account{},
@@ -379,6 +379,11 @@ func Migrate() {
 	if migrator.VersionCode == 32 {
 		// 添加刮削目录自定义定时任务字段
 		db.Db.AutoMigrate(ScrapePath{})
+		migrator.UpdateVersionCode(db.Db)
+	}
+	if migrator.VersionCode == 33 {
+		// 添加发布组和资源类型字段
+		db.Db.AutoMigrate(ScrapeMediaFile{})
 		migrator.UpdateVersionCode(db.Db)
 	}
 	helpers.AppLogger.Infof("当前数据库版本 %d", migrator.VersionCode)

--- a/internal/models/scrapemedia.go
+++ b/internal/models/scrapemedia.go
@@ -180,6 +180,8 @@ type ScrapeMediaFile struct {
 	VideoCodecJson       string            `json:"-"`                                               // 视频编码json字符串
 	AudioCodecJson       string            `json:"-"`                                               // 音频编码json字符串
 	SubtitleCodecJson    string            `json:"-"`                                               // 内封字幕流json字符串
+	ReleaseGroup         string            `json:"release_group"`                                   // 发布组
+	ResourceType         string            `json:"resource_type"`                                   // 资源类型
 	Status               ScrapeMediaStatus `json:"status"`                                          // 媒体状态
 	FailedReason         string            `json:"failed_reason"`                                   // 刮削失败原因
 	ScanTime             int64             `json:"scan_time"`                                       // 识别时间
@@ -633,6 +635,48 @@ func (sm *ScrapeMediaFile) GenerateNameByTemplate(template string) string {
 		newName = strings.ReplaceAll(newName, "{num}", sm.Media.Num)
 	} else {
 		newName = strings.ReplaceAll(newName, "{num}", "")
+	}
+	// en_title - 英文标题
+	if sm.Media != nil && sm.Media.OriginalName != "" {
+		newName = strings.ReplaceAll(newName, "{en_title}", sm.Media.OriginalName)
+	} else {
+		newName = strings.ReplaceAll(newName, "{en_title}", "")
+	}
+	// videoCodec - 视频编码
+	if sm.VideoCodec != nil && sm.VideoCodec.Micodec != "" {
+		newName = strings.ReplaceAll(newName, "{videoCodec}", sm.VideoCodec.Micodec)
+	} else if sm.VideoCodec != nil && sm.VideoCodec.Codec != "" {
+		newName = strings.ReplaceAll(newName, "{videoCodec}", sm.VideoCodec.Codec)
+	} else {
+		newName = strings.ReplaceAll(newName, "{videoCodec}", "")
+	}
+	// audioCodec - 音频编码
+	if len(sm.AudioCodec) > 0 && sm.AudioCodec[0].Micodec != "" {
+		newName = strings.ReplaceAll(newName, "{audioCodec}", sm.AudioCodec[0].Micodec)
+	} else if len(sm.AudioCodec) > 0 && sm.AudioCodec[0].Codec != "" {
+		newName = strings.ReplaceAll(newName, "{audioCodec}", sm.AudioCodec[0].Codec)
+	} else {
+		newName = strings.ReplaceAll(newName, "{audioCodec}", "")
+	}
+	// releaseGroup - 发布组
+	if sm.ReleaseGroup != "" {
+		newName = strings.ReplaceAll(newName, "{releaseGroup}", sm.ReleaseGroup)
+	} else {
+		newName = strings.ReplaceAll(newName, "{releaseGroup}", "")
+	}
+	// resourceType - 资源类型
+	if sm.ResourceType != "" {
+		newName = strings.ReplaceAll(newName, "{resourceType}", sm.ResourceType)
+	} else {
+		newName = strings.ReplaceAll(newName, "{resourceType}", "")
+	}
+	// original_name - 原始文件名
+	if sm.VideoFilename != "" {
+		// 移除文件扩展名
+		originalName := strings.TrimSuffix(sm.VideoFilename, sm.VideoExt)
+		newName = strings.ReplaceAll(newName, "{original_name}", originalName)
+	} else {
+		newName = strings.ReplaceAll(newName, "{original_name}", "")
 	}
 	if sm.MediaType == MediaTypeTvShow {
 		if sm.SeasonNumber >= 0 {

--- a/internal/scrape/id_movie.go
+++ b/internal/scrape/id_movie.go
@@ -80,6 +80,9 @@ func (i *IdMovieImpl) extractInfo(mediaFile *models.ScrapeMediaFile) (*helpers.M
 		}
 	} else if info.TmdbId != 0 {
 		helpers.AppLogger.Infof("使用正则提取电影信息成功, 文件名 %s, 文件夹：%s 提取结果 %+v", mediaFile.VideoFilename, filepath.Base(mediaFile.Path), info)
+		// 保存发布组和资源类型到 mediaFile
+		mediaFile.ReleaseGroup = info.ReleaseGroup
+		mediaFile.ResourceType = info.ResourceType
 		return &helpers.MediaInfo{
 			Name:   info.Name,
 			Year:   info.Year,

--- a/internal/scrape/id_tvshow.go
+++ b/internal/scrape/id_tvshow.go
@@ -250,6 +250,9 @@ func (i *IdTvShowImpl) extractInfoByREV2(mediaFile *models.ScrapeMediaFile) (*he
 	// 从文件名中获取媒体信息
 	info := helpers.ExtractMediaInfoRe(filename, false, false, i.scrapePath.VideoExtList, i.scrapePath.DeleteKeyword...)
 	helpers.AppLogger.Infof("正则从文件名中提取信息，文件名 %s， 提取结果 %+v", filename, info)
+	// 保存发布组和资源类型
+	mediaFile.ReleaseGroup = info.ReleaseGroup
+	mediaFile.ResourceType = info.ResourceType
 	info, err := i.find(mediaFile, info.TmdbId, info.Name, info.Year)
 	if err == nil {
 		return info, nil
@@ -257,6 +260,13 @@ func (i *IdTvShowImpl) extractInfoByREV2(mediaFile *models.ScrapeMediaFile) (*he
 	// 从文件夹中提取信息
 	folderInfo := helpers.ExtractMediaInfoRe(folderName, true, false, i.scrapePath.VideoExtList, i.scrapePath.DeleteKeyword...)
 	helpers.AppLogger.Infof("正则从文件夹中提取信息，文件夹 %s， 提取结果 %+v", folderName, folderInfo)
+	// 如果文件名没有提取到发布组或资源类型，尝试从文件夹提取
+	if mediaFile.ReleaseGroup == "" && folderInfo.ReleaseGroup != "" {
+		mediaFile.ReleaseGroup = folderInfo.ReleaseGroup
+	}
+	if mediaFile.ResourceType == "" && folderInfo.ResourceType != "" {
+		mediaFile.ResourceType = folderInfo.ResourceType
+	}
 	newInfo, ferr := i.find(mediaFile, folderInfo.TmdbId, folderInfo.Name, folderInfo.Year)
 	if ferr == nil {
 		return newInfo, nil

--- a/internal/scrape/scan/scan_base.go
+++ b/internal/scrape/scan/scan_base.go
@@ -261,7 +261,11 @@ func (m *scanBaseImpl) ExtractSeasonEpisode(mediaFile *models.ScrapeMediaFile) e
 		}
 		mediaFile.EpisodeNumber = info.Episode
 		mediaFile.SeasonNumber = info.Season
+		// 保存发布组和资源类型
+		mediaFile.ReleaseGroup = info.ReleaseGroup
+		mediaFile.ResourceType = info.ResourceType
 		helpers.AppLogger.Infof("从文件名中提取到季集: %s %d, %d", mediaFile.VideoFilename, mediaFile.SeasonNumber, mediaFile.EpisodeNumber)
+		helpers.AppLogger.Infof("从文件名中提取到发布组: %s, 资源类型: %s", mediaFile.ReleaseGroup, mediaFile.ResourceType)
 	}
 	if mediaFile.SeasonNumber == -1 {
 		// 从父目录中提取季数


### PR DESCRIPTION
## 📋 开发文档 - Issue #161

### 一、需求概述
为文件和文件夹整理模板增加6个新变量：`en_title`、`videoCodec`、`audioCodec`、`releaseGroup`、`resourceType`、`original_name`

### 二、技术分析

#### 2.1 现有变量
当前 `GenerateNameByTemplate` 函数已支持的变量：
- `{title}` - 标题
- `{year}` - 年份
- `{resolution}` - 分辨率
- `{resolution_level}` - 分辨率等级
- `{bitrate}` - 码率
- `{tmdb_id}` - TMDB ID
- `{actors}` - 演员
- `{num}` - 编号
- `{season_number}`、`{episode_number}`、`{season_episode}`、`{episode_name}`（剧集专用）

#### 2.2 数据来源分析

1. **en_title（英文标题）**
   - 数据来源：`Media.OriginalName` 字段
   - TMDB 已返回：`movie_detail.OriginalTitle` / `tv_detail.OriginalName`
   - 已存储到数据库：Media 表的 `original_title` 字段

2. **videoCodec（视频编码）**
   - 数据来源：`ScrapeMediaFile.VideoCodec` 结构体
   - 字段：`VideoCodec.Codec` 或 `VideoCodec.Micodec`
   - 已通过 ffprobe 提取并存储

3. **audioCodec（音频编码）**
   - 数据来源：`ScrapeMediaFile.AudioCodec` 数组
   - 字段：`AudioCodec[0].Codec` 或 `AudioCodec[0].Micodec`
   - 已通过 ffprobe 提取并存储

4. **original_name（原始文件名）**
   - 数据来源：`ScrapeMediaFile.VideoFilename` 字段
   - 已存储

5. **releaseGroup（发布组）**
   - 数据来源：从文件名中解析
   - 需要扩展 `MediaInfo` 结构体，添加 `ReleaseGroup` 字段
   - 需要扩展 `ExtractMediaInfoRe` 函数，添加发布组识别逻辑

6. **resourceType（资源类型）**
   - 数据来源：从文件名中解析
   - 需要扩展 `MediaInfo` 结构体，添加 `ResourceType` 字段
   - 需要扩展 `ExtractMediaInfoRe` 函数，添加资源类型识别逻辑

### 三、实现方案

#### 3.1 扩展 MediaInfo 结构体
文件：`internal/helpers/extract.go`

```go
type MediaInfo struct {
    Name         string `json:"name"`
    Year         int    `json:"year"`
    Season       int    `json:"season"`
    Episode      int    `json:"episode"`
    TmdbId       int64  `json:"tmdbid"`
    ReleaseGroup string `json:"release_group"`  // 新增：发布组
    ResourceType string `json:"resource_type"`  // 新增：资源类型
}
```

#### 3.2 扩展文件名解析逻辑
文件：`internal/helpers/extract.go`

在 `ExtractMediaInfoRe` 函数中添加发布组和资源类型识别：

**发布组识别规则：**
- 匹配文件名末尾的发布组标记（通常是最后一个横杠后的名称）
- 示例：`-PTGroup`、`-CtrlHD`、`-FraMeSToR`
- 使用正则：`-(\w{2,})$`

**资源类型识别规则：**
- BluRay/Remux：匹配包含`BluRay`、`bluray`、`blue-ray`、`Remux`
- WEB-DL：匹配包含`WEB-DL`、`WEBDL`、`Amazon`、`Netflix`
- HDTV：匹配包含`HDTV`、`TVRip`
- DVD：匹配包含`DVD`、`DVD5`、`DVD9`

#### 3.3 扩展 ScrapeMediaFile 结构体
文件：`internal/models/scrapemedia.go`

添加新字段（用于存储解析后的信息）：

```go
type ScrapeMediaFile struct {
    // ... 现有字段 ...
    ReleaseGroup string `json:"release_group"` // 发布组
    ResourceType string `json:"resource_type"` // 资源类型
}
```

#### 3.4 扩展模板替换逻辑
文件：`internal/models/scrapemedia.go`

在 `GenerateNameByTemplate` 函数中添加新变量替换逻辑

#### 3.5 更新数据库迁移
需要添加数据库迁移脚本，在 `scrape_media_files` 表中添加新字段：
- `release_group` (VARCHAR)
- `resource_type` (VARCHAR)

#### 3.6 更新文件名解析调用
在刮削过程中，需要将解析到的 `ReleaseGroup` 和 `ResourceType` 保存到 `ScrapeMediaFile`

### 四、开发步骤

1. ✅ 需求分析和技术调研
2. 扩展 MediaInfo 结构体
3. 实现发布组识别逻辑
4. 实现资源类型识别逻辑
5. 扩展 ScrapeMediaFile 结构体
6. 创建数据库迁移脚本
7. 更新模板替换逻辑
8. 更新文件名解析调用
9. 单元测试
10. 集成测试

### 五、测试计划

#### 5.1 单元测试
- 测试发布组识别（多种命名格式）
- 测试资源类型识别（BluRay、WEB-DL、HDTV、DVD）
- 测试模板变量替换（包含新变量的模板）

#### 5.2 集成测试
- 测试完整刮削流程（电影和剧集）
- 验证数据库字段正确存储
- 验证整理后的文件名/文件夹名符合预期

#### 5.3 测试用例
- 外国电影：验证 en_title 变量
- PT资源：验证 videoCodec、audioCodec、releaseGroup、resourceType 变量
- 原始文件名：验证 original_name 变量
- 元数据缺失：验证变量为空且不影响整体命名
- 特殊字符：验证特殊字符处理

### 六、风险评估

1. **兼容性风险**：低 - 新增字段不会影响现有逻辑
2. **解析准确性风险**：中 - 发布组和资源类型的正则表达式需要充分测试
3. **性能风险**：低 - 只增加少量字符串操作

### 七、验收标准

对照Issue中的验收标准，确保所有标准都满足。

---

**状态：开发中**
**开始时间：2026-03-18 18:35**