### PR TITLE
Issue #185: [Bug] 2160p视频错误识别为360p（分辨率计算逻辑错误）

### DIFF
--- a/internal/scrape/scrape_base.go
+++ b/internal/scrape/scrape_base.go
@@ -103,28 +103,31 @@ func (sm *ScrapeBase) GetFFprobeInfoFromFileOrUrl(mediaFile *models.ScrapeMediaF
 	for index, stream := range ffprobeJson.Streams {
 		// 解析视频编码
 		if stream.CodecType == "video" {
-			mediaFile.VideoCodec = &models.VideoCodec{}
-			mediaFile.VideoCodec.StreamIndex = index
-			mediaFile.VideoCodec.Codec = stream.CodecName
-			mediaFile.VideoCodec.Micodec = stream.CodecName
-			mediaFile.VideoCodec.Width = stream.Width
-			mediaFile.VideoCodec.Height = stream.Height
-			mediaFile.VideoCodec.Duration = ffprobeJson.Format.Duration
-			mediaFile.VideoCodec.AspectRatio = helpers.CalculateAspectRatio(stream.Width, stream.Height)
-			mediaFile.VideoCodec.Aspect = stream.DisplayAspectRatio
-			mediaFile.VideoCodec.PixelFormat = stream.PixelFormat
-			bitrate, err := helpers.CalculateBitrate(&stream, &ffprobeJson.Format)
-			if err == nil {
-				mediaFile.VideoCodec.Bitrate = bitrate
-			} else {
-				mediaFile.VideoCodec.Bitrate = 0
-			}
-			mediaFile.VideoCodec.Framerate = stream.AvgFrameRate
-			mediaFile.VideoCodec.DurationInSeconds, _ = helpers.ParseDurationToSeconds(ffprobeJson.Format.Duration)
-			if mediaFile.VideoCodec.DurationInSeconds > 0 {
-				mediaFile.VideoCodec.DurationInMinutes = mediaFile.VideoCodec.DurationInSeconds / 60
-			} else {
-				mediaFile.VideoCodec.DurationInMinutes = 0
+			// 只处理第一个视频流，避免封面图流覆盖主视频流的信息
+			if mediaFile.VideoCodec == nil {
+				mediaFile.VideoCodec = &models.VideoCodec{}
+				mediaFile.VideoCodec.StreamIndex = index
+				mediaFile.VideoCodec.Codec = stream.CodecName
+				mediaFile.VideoCodec.Micodec = stream.CodecName
+				mediaFile.VideoCodec.Width = stream.Width
+				mediaFile.VideoCodec.Height = stream.Height
+				mediaFile.VideoCodec.Duration = ffprobeJson.Format.Duration
+				mediaFile.VideoCodec.AspectRatio = helpers.CalculateAspectRatio(stream.Width, stream.Height)
+				mediaFile.VideoCodec.Aspect = stream.DisplayAspectRatio
+				mediaFile.VideoCodec.PixelFormat = stream.PixelFormat
+				bitrate, err := helpers.CalculateBitrate(&stream, &ffprobeJson.Format)
+				if err == nil {
+					mediaFile.VideoCodec.Bitrate = bitrate
+				} else {
+					mediaFile.VideoCodec.Bitrate = 0
+				}
+				mediaFile.VideoCodec.Framerate = stream.AvgFrameRate
+				mediaFile.VideoCodec.DurationInSeconds, _ = helpers.ParseDurationToSeconds(ffprobeJson.Format.Duration)
+				if mediaFile.VideoCodec.DurationInSeconds > 0 {
+					mediaFile.VideoCodec.DurationInMinutes = mediaFile.VideoCodec.DurationInSeconds / 60
+				} else {
+					mediaFile.VideoCodec.DurationInMinutes = 0
+				}
 			}
 		}
 		// 解析音频编码


### PR DESCRIPTION
# 开发文档 - Issue #185

## 需求概述

修复2160p（4K）视频被错误识别为360p的Bug。实际分辨率为3840x2160的视频，被QMS错误识别为360p。

## 技术分析

### 问题根源

通过代码分析，发现问题出在 `internal/scrape/scrape_base.go` 的 `GetFFprobeInfoFromFileOrUrl` 函数中：

```go
for index, stream := range ffprobeJson.Streams {
    if stream.CodecType == "video" {
        mediaFile.VideoCodec = &models.VideoCodec{}
        mediaFile.VideoCodec.Width = stream.Width
        mediaFile.VideoCodec.Height = stream.Height
        // ... 其他设置
    }
}
```

**问题**：
1. 代码会遍历所有流，找到所有 `codec_type == "video"` 的流
2. 对于每个视频流，都会创建新的 `VideoCodec` 对象并覆盖之前的对象
3. 如果视频文件中有多个视频流（例如：主视频流 3840x2160 + 封面图流 640x360），后面的视频流会覆盖前面的视频流
4. 导致最终获取的是最后一个视频流的分辨率，而不是主视频流的分辨率

### 复现场景

对于文件 `Avatar.2009.Theatrical.Release.2160p.BluRay.REMUX.HDR.DV.HEVC.DTS-HD.MA.TrueHD.7.1.Atmos.mkv`：
1. ffprobe 返回多个视频流：
   - Stream 0: 主视频流（3840x2160）
   - Stream 1: 封面图流（640x360）
2. 代码遍历流时，先处理 Stream 0（3840x2160）
3. 然后处理 Stream 1（640x360），覆盖了 Stream 0 的信息
4. 最终 `mediaFile.VideoCodec.Width = 640`, `mediaFile.VideoCodec.Height = 360`
5. 分辨率识别逻辑将 640x360 识别为 360p

### 分辨率识别逻辑

`internal/helpers/ffprobe.go` 中的 `DetectResolution` 函数：
1. **精确匹配**：在 `resolutionLibrary` 中查找完全匹配的分辨率
2. **容差匹配**：如果精确匹配失败，使用容差（64像素）进行匹配
3. **估算**：如果容差匹配也失败，基于宽高比估算

分辨率识别逻辑本身是正确的，问题在于传入的宽度和高度不正确。

## 数据库更改

无需数据库更改。

## 前端更改

无前端更改。

## 实现方案

### 方案1：只处理第一个视频流（推荐）

**优点**：
- 简单直接，容易理解
- 符合大多数视频文件的实际情况（主视频流在前面）
- 不会引入额外的复杂性

**缺点**：
- 如果封面图流在前面，主视频流在后面，可能会获取错误的分辨率
- 但是这种情况比较少见

**实现**：
```go
for index, stream := range ffprobeJson.Streams {
    if stream.CodecType == "video" {
        // 只处理第一个视频流
        if mediaFile.VideoCodec == nil {
            mediaFile.VideoCodec = &models.VideoCodec{}
            mediaFile.VideoCodec.StreamIndex = index
            mediaFile.VideoCodec.Codec = stream.CodecName
            mediaFile.VideoCodec.Micodec = stream.CodecName
            mediaFile.VideoCodec.Width = stream.Width
            mediaFile.VideoCodec.Height = stream.Height
            // ... 其他设置
        }
    }
}
```

### 方案2：选择分辨率最高的视频流（备选）

**优点**：
- 更健壮，可以处理各种情况
- 即使封面图流在前面，也能正确识别主视频流

**缺点**：
- 实现复杂度较高
- 可能会引入其他问题（例如：如果有多个高分辨率视频流，如何选择？）

**实现**：
```go
var maxWidth, maxHeight int
var bestStreamIndex int
var bestStream *ffprobeStream

for index, stream := range ffprobeJson.Streams {
    if stream.CodecType == "video" {
        // 选择分辨率最高的视频流
        if stream.Width*stream.Height > maxWidth*maxHeight {
            maxWidth = stream.Width
            maxHeight = stream.Height
            bestStreamIndex = index
            bestStream = &stream
        }
    }
}

if bestStream != nil {
    mediaFile.VideoCodec = &models.VideoCodec{}
    mediaFile.VideoCodec.StreamIndex = bestStreamIndex
    mediaFile.VideoCodec.Codec = bestStream.CodecName
    // ... 其他设置
}
```

### 推荐方案

**选择方案1：只处理第一个视频流**

理由：
1. 大多数视频文件的主视频流都在前面
2. 实现简单，不易出错
3. 符合现有的代码逻辑
4. 如果后续发现问题，可以再优化

## 测试计划

### 单元测试

无需新增单元测试（现有代码逻辑修改）。

### 集成测试

1. **测试用例1：3840x2160 的视频**
   - 输入：包含多个视频流的 4K 视频文件
   - 预期：正确识别为 2160p

2. **测试用例2：1920x1080 的视频**
   - 输入：包含多个视频流的 1080p 视频文件
   - 预期：正确识别为 1080p

3. **测试用例3：1280x720 的视频**
   - 输入：包含多个视频流的 720p 视频文件
   - 预期：正确识别为 720p

4. **测试用例4：640x360 的视频**
   - 输入：单个视频流的 360p 视频文件
   - 预期：正确识别为 360p

### 端到端测试

无需端到端测试。

## 风险评估

### 风险1：封面图流在前面

**可能性**：低
**影响**：中等
**缓解措施**：
- 如果用户反馈有此问题，可以切换到方案2

### 风险2：修复后影响其他分辨率识别

**可能性**：低
**影响**：高
**缓解措施**：
- 在测试环境中充分测试各种分辨率的视频文件
- 监控用户反馈

## 实施步骤

1. 修改 `internal/scrape/scrape_base.go` 的 `GetFFprobeInfoFromFileOrUrl` 函数
2. 添加 `if mediaFile.VideoCodec == nil` 条件判断
3. 添加注释说明原因
4. 执行测试（代码格式化、语法检查、编译检查、单元测试）
5. 提交代码
6. 创建 PR

## 相关文件

- `internal/scrape/scrape_base.go` - 媒体信息提取
- `internal/helpers/ffprobe.go` - 分辨率识别逻辑

## 参考资料

- Issue #184 - 同样的问题，已修复但未合并
- [FFprobe 文档](https://ffmpeg.org/ffprobe.html)