### PR TITLE
Issue #189: [Bug] TMDB设置保存后容器重启会丢失配置恢复默认

### DIFF
--- a/internal/models/migrator.go
+++ b/internal/models/migrator.go
@@ -18,7 +18,7 @@ type Migrator struct {
 	VersionCode int `json:"version_code"` // 版本号
 }
 
-var MaxVersionCode = 35
+var MaxVersionCode = 36
 var AllTables = []any{
 	BackupConfig{}, BackupRecord{},
 	ApiKey{}, Settings{}, Sync{}, User{}, Account{},
@@ -423,6 +423,28 @@ func Migrate() {
 		helpers.AppLogger.Infof("更新EmbyMediaItem item_id_int字段完成")
 		migrator.UpdateVersionCode(db.Db)
 	}
+	if migrator.VersionCode == 35 {
+		// 清理重复的 ScrapeSettings 记录
+		var count int64
+		db.Db.Model(&ScrapeSettings{}).Count(&count)
+		if count > 1 {
+			helpers.AppLogger.Infof("发现%d条刮削设置记录，清理重复记录", count)
+			var allSettings []*ScrapeSettings
+			db.Db.Order("id asc").Find(&allSettings)
+			// 保留第一条，删除其余的
+			for i := 1; i < len(allSettings); i++ {
+				if err := db.Db.Delete(allSettings[i]).Error; err != nil {
+					helpers.AppLogger.Errorf("删除重复的刮削设置记录失败，ID=%d: %v", allSettings[i].ID, err)
+				} else {
+					helpers.AppLogger.Infof("删除重复的刮削设置记录，ID=%d", allSettings[i].ID)
+				}
+			}
+		} else if count == 0 {
+			helpers.AppLogger.Warnf("数据库中没有刮削设置记录，将创建默认记录")
+			InitScrapeSetting()
+		}
+		migrator.UpdateVersionCode(db.Db)
+	}
 	helpers.AppLogger.Infof("当前数据库版本 %d", migrator.VersionCode)
 }
 
@@ -534,6 +556,14 @@ func InitUser() {
 }
 
 func InitScrapeSetting() {
+	// 先检查是否已存在记录
+	var count int64
+	db.Db.Model(&ScrapeSettings{}).Count(&count)
+	if count > 0 {
+		helpers.AppLogger.Info("刮削设置已存在，跳过初始化")
+		return
+	}
+
 	// 添加默认值
 	scrapeSettings := ScrapeSettings{
 		TmdbApiKey:      "",

--- a/internal/models/scrape.go
+++ b/internal/models/scrape.go
@@ -42,12 +42,26 @@ const (
 var GlobalScrapeSettings = &ScrapeSettings{}
 
 func LoadScrapeSettings() *ScrapeSettings {
-	if err := db.Db.Take(GlobalScrapeSettings).Error; err != nil {
+	// 检查是否存在记录
+	var count int64
+	db.Db.Model(&ScrapeSettings{}).Count(&count)
+
+	if count == 0 {
+		helpers.AppLogger.Warnf("数据库中没有刮削设置记录，将创建默认记录")
+		// 创建默认记录
+		InitScrapeSetting()
+	}
+
+	if count > 1 {
+		helpers.AppLogger.Warnf("数据库中存在多条刮削设置记录（%d条），将只使用第一条", count)
+	}
+
+	if err := db.Db.First(GlobalScrapeSettings).Error; err != nil {
 		helpers.AppLogger.Errorf("加载刮削设置失败: %v", err)
 		return nil
 	}
 
-	helpers.AppLogger.Infof("从数据库读取刮削设置成功")
+	helpers.AppLogger.Infof("从数据库读取刮削设置成功，ID=%d", GlobalScrapeSettings.ID)
 	return GlobalScrapeSettings
 }
 
@@ -106,6 +120,7 @@ func (s *ScrapeSettings) GetTmdbClient() *tmdb.Client {
 
 // 保存tmdb设置
 func (s *ScrapeSettings) SaveTmdb(apiKey, accessToken string, apiUrl string, imageUrl string, language string, imageLanguage string, enableProxy bool) error {
+	// 更新全局对象
 	s.TmdbApiKey = apiKey
 	s.TmdbAccessToken = accessToken
 	s.TmdbUrl = apiUrl
@@ -113,6 +128,8 @@ func (s *ScrapeSettings) SaveTmdb(apiKey, accessToken string, apiUrl string, ima
 	s.TmdbLanguage = language
 	s.TmdbImageLanguage = imageLanguage
 	s.TmdbEnableProxy = enableProxy
+
+	// 准备更新数据
 	updateData := make(map[string]interface{})
 	updateData["tmdb_api_key"] = apiKey
 	updateData["tmdb_access_token"] = accessToken
@@ -121,11 +138,21 @@ func (s *ScrapeSettings) SaveTmdb(apiKey, accessToken string, apiUrl string, ima
 	updateData["tmdb_language"] = language
 	updateData["tmdb_image_language"] = imageLanguage
 	updateData["tmdb_enable_proxy"] = enableProxy
-	err := db.Db.Model(ScrapeSettings{}).Where("id = ?", s.ID).Updates(updateData).Error
-	if err != nil {
-		helpers.AppLogger.Errorf("更新TMDB设置失败: %v", err)
-		return err
+
+	// 使用 s 作为 Model 参数，确保更新正确的记录
+	result := db.Db.Model(s).Updates(updateData)
+	if result.Error != nil {
+		helpers.AppLogger.Errorf("更新TMDB设置失败: %v", result.Error)
+		return result.Error
 	}
+
+	// 检查是否真的更新了记录
+	if result.RowsAffected == 0 {
+		helpers.AppLogger.Warnf("更新TMDB设置：没有记录被更新，ID=%d", s.ID)
+		return fmt.Errorf("没有找到要更新的记录")
+	}
+
+	helpers.AppLogger.Infof("TMDB设置已成功更新，ID=%d，影响行数=%d", s.ID, result.RowsAffected)
 	return nil
 }
 


### PR DESCRIPTION
## 问题描述
在"刮削 & 整理" → "TMDB设置"页面修改配置并保存后，容器重启会丢失所有设置，恢复到默认值。

## 影响范围
所有TMDB设置页面中的配置项：
- TMDB接口地址、图片地址
- 是否启用代理
- API密钥、Access Token
- 首选元数据语言
- 首选图片语言

## 根本原因
1. **初始化时未检查记录是否已存在**：`InitScrapeSetting()` 未检查数据库中是否已有 ScrapeSettings 记录，可能导致创建重复记录
2. **保存逻辑可能无法找到正确的记录**：`SaveTmdb()` 使用 `Model(ScrapeSettings{})` 而不是 `Model(s)`，可能无法正确更新记录
3. **缺少错误日志和调试信息**：保存失败时无法确定是否真的成功

## 修复方案

### 阶段1：修复初始化逻辑
- 在 `InitScrapeSetting()` 中添加记录存在检查
- 确保数据库中只有一条 ScrapeSettings 记录

### 阶段2：修复保存逻辑
- 修改 `SaveTmdb()` 使用 `Model(s)` 而不是 `Model(ScrapeSettings{})`
- 添加 `RowsAffected` 检查，确保记录被正确更新
- 增加详细日志记录

### 阶段3：增强加载逻辑
- 在 `LoadScrapeSettings()` 中添加记录数量检查
- 如果数据库为空，自动创建默认记录
- 如果有多条记录，发出警告

### 阶段4：添加数据库清理迁移脚本
- 添加版本 35 迁移，清理重复的 ScrapeSettings 记录
- 只保留 ID 最小的记录

## 修改文件
- `internal/models/migrator.go`
- `internal/models/scrape.go`

## 测试结果
- ✅ 代码格式化检查（gofmt）
- ✅ 语法检查（go vet）
- ✅ 编译检查（go build）
- ✅ 单元测试通过

## 预期效果
修复后，TMDB 设置将能够正确保存和加载，容器重启后不会丢失配置。