### PR TITLE
Issue #191: 删除整理完的非空路径功能失效 - Season文件夹残留未删除

### DIFF
--- a/internal/scrape/rename/rename_baidupan.go
+++ b/internal/scrape/rename/rename_baidupan.go
@@ -270,9 +270,11 @@ func (r *RenameBaiduPan) CheckAndMkDir(destFullPath string, rootPath, rootPathId
 }
 
 func (r *RenameBaiduPan) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile, sp *models.ScrapePath) error {
+	hasSeason := true
 	sourcePath := mediaFile.PathId
 	if sourcePath == "" && mediaFile.MediaType == models.MediaTypeTvShow {
 		sourcePath = mediaFile.TvshowPathId
+		hasSeason = false
 	}
 	fsList, err := r.client.GetFileList(r.ctx, sourcePath, 1, 1, 0, 1000)
 	if err != nil {
@@ -292,7 +294,7 @@ func (r *RenameBaiduPan) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile
 			helpers.AppLogger.Info("视频文件的父目录是来源根路径，不删除")
 			return nil
 		}
-		// 删除目录
+		// 删除目录（Season 文件夹或电影文件夹）
 		err := r.client.Del(r.ctx, []string{sourcePath})
 		if err != nil {
 			helpers.AppLogger.Errorf("百度网盘 删除文件夹失败: %s %v", sourcePath, err)
@@ -300,29 +302,36 @@ func (r *RenameBaiduPan) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile
 		}
 		helpers.AppLogger.Infof("刮削完成，尝试删除百度网盘文件夹成功, 路径：%s", sourcePath)
 	}
-	// 再删除电视剧文件夹
-	if mediaFile.PathId != "" {
+	// 如果有 Season 文件夹，再尝试删除电视剧主文件夹
+	if mediaFile.PathId != "" && hasSeason {
 		// 检查电视剧文件夹的父目录是否是来源根路径
-		tvshowParentId := mediaFile.TvshowPathId
-		if tvshowParentId == sp.SourcePath {
+		if mediaFile.TvshowPathId == sp.SourcePath {
 			helpers.AppLogger.Info("电视剧的父目录是来源根路径，不删除")
 			return nil
 		}
-		fsList, err := r.client.GetFileList(r.ctx, tvshowParentId, 1, 1, 0, 1000)
+		tvshowFsList, err := r.client.GetFileList(r.ctx, mediaFile.TvshowPathId, 1, 1, 0, 1000)
 		if err != nil {
-			helpers.AppLogger.Errorf("删除Openlist文件失败: %s %v", mediaFile.PathId, err)
+			helpers.AppLogger.Errorf("百度网盘 获取电视剧文件夹列表失败: %s %v", mediaFile.TvshowPathId, err)
 			return err
 		}
-		if len(fsList) == 0 || sp.ForceDeleteSourcePath {
-			// 删除目录
-			err := r.client.Del(r.ctx, []string{tvshowParentId})
+		// 检查电视剧主文件夹下是否还有其他目录（其他 Season 文件夹）
+		if len(tvshowFsList) > 0 {
+			for _, file := range tvshowFsList {
+				if file.IsDir == 1 {
+					helpers.AppLogger.Infof("电视剧目录 %s 下还有其他目录 %s，不删除电视剧主文件夹", mediaFile.TvshowPathId, file.ServerFilename)
+					return nil
+				}
+			}
+		}
+		// 删除电视剧主文件夹
+		if len(tvshowFsList) == 0 || sp.ForceDeleteSourcePath {
+			err := r.client.Del(r.ctx, []string{mediaFile.TvshowPathId})
 			if err != nil {
 				helpers.AppLogger.Errorf("删除百度网盘电视剧文件夹失败: %s %v", mediaFile.TvshowPathId, err)
 				return err
 			}
 			helpers.AppLogger.Infof("刮削完成，尝试删除百度网盘电视剧文件夹成功, 路径：%s", mediaFile.TvshowPathId)
 		}
-
 	}
 	return nil
 }

--- a/internal/scrape/rename/rename_local.go
+++ b/internal/scrape/rename/rename_local.go
@@ -346,9 +346,11 @@ func (r *RenameLocal) CheckAndMkDir(destFullPath string, rootPath, rootPathId st
 }
 
 func (r *RenameLocal) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile, sp *models.ScrapePath) error {
+	hasSeason := true
 	sourcePath := mediaFile.PathId
 	if sourcePath == "" && mediaFile.MediaType == models.MediaTypeTvShow {
 		sourcePath = mediaFile.TvshowPathId
+		hasSeason = false
 	}
 	if sourcePath == sp.SourcePath {
 		helpers.AppLogger.Info("视频文件的父目录是来源根路径，不删除")
@@ -366,7 +368,7 @@ func (r *RenameLocal) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile, s
 		}
 	}
 	if len(dirEntries) == 0 || sp.ForceDeleteSourcePath {
-		// 删除本地目录
+		// 删除本地目录（Season 文件夹或电影文件夹）
 		err := os.RemoveAll(sourcePath)
 		if err != nil {
 			helpers.AppLogger.Errorf("删除本地目录失败: %s %v", sourcePath, err)
@@ -374,17 +376,25 @@ func (r *RenameLocal) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile, s
 		}
 		helpers.AppLogger.Infof("刮削完成，尝试删除本地目录成功, 路径：%s", sourcePath)
 	}
-	// 如果有电视剧文件夹，则删除
-	if mediaFile.PathId != "" {
+	// 如果有 Season 文件夹，再尝试删除电视剧主文件夹
+	if mediaFile.PathId != "" && hasSeason {
 		// 检查电视剧文件夹的父目录是否是来源根路径
-		tvshowParentId := mediaFile.TvshowPathId
-		if tvshowParentId == sp.SourcePathId {
+		if mediaFile.TvshowPathId == sp.SourcePathId {
 			helpers.AppLogger.Info("电视剧的父目录是来源根路径，不删除")
 			return nil
 		}
-		// 判断这个目录下是否没有任何其他文件或目录
-		dirEntries, _ := os.ReadDir(tvshowParentId)
-		if len(dirEntries) == 0 || sp.ForceDeleteSourcePath {
+		// 检查电视剧主文件夹下是否还有其他目录（其他 Season 文件夹）
+		tvshowDirEntries, _ := os.ReadDir(mediaFile.TvshowPathId)
+		if len(tvshowDirEntries) > 0 {
+			for _, entry := range tvshowDirEntries {
+				if entry.IsDir() {
+					helpers.AppLogger.Infof("电视剧目录 %s 下还有其他目录 %s，不删除电视剧主文件夹", mediaFile.TvshowPathId, entry.Name())
+					return nil
+				}
+			}
+		}
+		// 删除电视剧主文件夹
+		if len(tvshowDirEntries) == 0 || sp.ForceDeleteSourcePath {
 			err := os.RemoveAll(mediaFile.TvshowPathId)
 			if err != nil {
 				helpers.AppLogger.Errorf("删除电视剧文件夹失败: %s %v", mediaFile.TvshowPathId, err)

--- a/internal/scrape/rename/rename_openlist.go
+++ b/internal/scrape/rename/rename_openlist.go
@@ -344,9 +344,11 @@ func (r *RenameOpenList) CheckAndMkDir(destFullPath string, rootPath, rootPathId
 }
 
 func (r *RenameOpenList) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile, sp *models.ScrapePath) error {
+	hasSeason := true
 	sourcePath := mediaFile.PathId
 	if sourcePath == "" && mediaFile.MediaType == models.MediaTypeTvShow {
 		sourcePath = mediaFile.TvshowPathId
+		hasSeason = false
 	}
 	fsDetail, err := r.client.FileList(r.ctx, sourcePath, 1, 10)
 	if err != nil {
@@ -366,7 +368,7 @@ func (r *RenameOpenList) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile
 			helpers.AppLogger.Info("视频文件的父目录是来源根路径，不删除")
 			return nil
 		}
-		// 删除目录
+		// 删除目录（Season 文件夹或电影文件夹）
 		err := r.client.Del(filepath.Dir(sourcePath), []string{filepath.Base(sourcePath)})
 		if err != nil {
 			helpers.AppLogger.Errorf("删除Openlist文件失败: %s %v", sourcePath, err)
@@ -374,29 +376,36 @@ func (r *RenameOpenList) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile
 		}
 		helpers.AppLogger.Infof("刮削完成，尝试删除Openlist文件夹成功, 路径：%s", sourcePath)
 	}
-	// 再删除电视剧文件夹
-	if mediaFile.PathId != "" {
+	// 如果有 Season 文件夹，再尝试删除电视剧主文件夹
+	if mediaFile.PathId != "" && hasSeason {
 		// 检查电视剧文件夹的父目录是否是来源根路径
-		tvshowParentId := mediaFile.TvshowPathId
-		if tvshowParentId == sp.SourcePath {
+		if mediaFile.TvshowPathId == sp.SourcePath {
 			helpers.AppLogger.Info("电视剧的父目录是来源根路径，不删除")
 			return nil
 		}
-		fsDetail, err := r.client.FileList(r.ctx, tvshowParentId, 1, 10)
+		tvshowFsDetail, err := r.client.FileList(r.ctx, mediaFile.TvshowPathId, 1, 10)
 		if err != nil {
-			helpers.AppLogger.Errorf("删除Openlist文件失败: %s %v", mediaFile.PathId, err)
+			helpers.AppLogger.Errorf("获取Openlist电视剧文件夹列表失败: %s %v", mediaFile.TvshowPathId, err)
 			return err
 		}
-		if fsDetail.Total == 0 || sp.ForceDeleteSourcePath {
-			// 删除目录
-			err := r.client.Del(tvshowParentId, []string{filepath.Base(tvshowParentId)})
+		// 检查电视剧主文件夹下是否还有其他目录（其他 Season 文件夹）
+		if tvshowFsDetail.Total > 0 {
+			for _, file := range tvshowFsDetail.Content {
+				if file.IsDir {
+					helpers.AppLogger.Infof("电视剧目录 %s 下还有其他目录 %s，不删除电视剧主文件夹", mediaFile.TvshowPathId, file.Name)
+					return nil
+				}
+			}
+		}
+		// 删除电视剧主文件夹
+		if tvshowFsDetail.Total == 0 || sp.ForceDeleteSourcePath {
+			err := r.client.Del(filepath.Dir(mediaFile.TvshowPathId), []string{filepath.Base(mediaFile.TvshowPathId)})
 			if err != nil {
-				helpers.AppLogger.Errorf("删除Openlist文件失败: %s %v", mediaFile.TvshowPathId, err)
+				helpers.AppLogger.Errorf("删除Openlist电视剧文件夹失败: %s %v", mediaFile.TvshowPathId, err)
 				return err
 			}
 			helpers.AppLogger.Infof("刮削完成，尝试删除Openlist中的电视剧文件夹成功, 路径：%s", mediaFile.TvshowPathId)
 		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
# 开发文档 - Issue #191

## 需求概述

**Bug描述**：在刮削目录设置中开启了"删除整理完的非空路径"（`ForceDeleteSourcePath`），但整理完成后，空的Season子文件夹仍然残留，未被删除。

**复现场景**：
- **有问题的场景**：两层文件夹结构（剧集主文件夹 + Season子文件夹）
  - 整理完成后，Season子文件夹残留，未删除 ❌
- **正常的场景**：单层文件夹结构（剧集主文件夹 + 视频文件）
  - 整理后主文件夹被正确删除 ✅

**影响范围**：
- 功能影响："删除整理完的非空路径"功能在两层文件夹结构下失效
- 用户体验：整理完成后，会有大量空的Season文件夹残留
- 维护成本：用户需要手动删除这些空文件夹

## 技术分析

### 代码流程

**删除逻辑入口**：`internal/scrape/rename/rename_*.go` 的 `RemoveMediaSourcePath` 函数

**调用时机**：整理完成后，调用 `RemoveMediaSourcePath` 删除源路径

**当前实现（以本地文件系统为例）**：
```go
func (r *RenameLocal) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile, sp *models.ScrapePath) error {
	// 1. 先删除 Season 文件夹（或电影的媒体文件夹）
	sourcePath := mediaFile.PathId
	if sourcePath == "" && mediaFile.MediaType == models.MediaTypeTvShow {
		sourcePath = mediaFile.TvshowPathId
	}
	
	// 检查是否为空，如果为空或 ForceDeleteSourcePath = true，删除
	if len(dirEntries) == 0 || sp.ForceDeleteSourcePath {
		os.RemoveAll(sourcePath)
	}
	
	// 2. 再删除电视剧主文件夹
	if mediaFile.PathId != "" {
		tvshowParentId := mediaFile.TvshowPathId
		// 检查是否为空，如果为空或 ForceDeleteSourcePath = true，删除
		if len(dirEntries) == 0 || sp.ForceDeleteSourcePath {
			os.RemoveAll(mediaFile.TvshowPathId)
		}
	}
}
```

### 根本原因分析

经过详细的代码对比分析，我发现了问题：

**问题1：本地文件系统缺少 `hasSeason` 检查逻辑**

**115 网盘的实现（有 `hasSeason` 检查）**：
```go
func (r *Rename115) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile, sp *models.ScrapePath) error {
	hasSeason := true
	sourcePathId := mediaFile.PathId
	if sourcePathId == "" {
		sourcePathId = mediaFile.TvshowPathId
		hasSeason = false
	}
	
	// 删除 Season 文件夹
	if fsList.Count == 0 || sp.ForceDeleteSourcePath {
		r.client.Del(r.ctx, []string{sourcePathId}, parentId)
	}
	
	// 再删除电视剧文件夹
	if mediaFile.PathId != "" {
		if hasSeason {
			// 检查电视剧目录下是否还有其他季目录
			tvshowFileList, _ := r.client.GetFsList(r.ctx, mediaFile.TvshowPathId, true, false, true, 1, 10)
			for _, tvshowFile := range tvshowFileList.Data {
				if tvshowFile.FileCategory == v115open.TypeDir {
					// 还有其他季目录，不删除
					return nil
				}
			}
		}
		// 删除电视剧主文件夹
		if fsDetail.Count == "0" || sp.ForceDeleteSourcePath {
			r.client.Del(r.ctx, []string{mediaFile.TvshowPathId}, tvshowParentId)
		}
	}
}
```

**本地文件系统的实现（缺少 `hasSeason` 检查）**：
```go
func (r *RenameLocal) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile, sp *models.ScrapePath) error {
	sourcePath := mediaFile.PathId
	if sourcePath == "" && mediaFile.MediaType == models.MediaTypeTvShow {
		sourcePath = mediaFile.TvshowPathId
	}
	
	// 删除 Season 文件夹
	if len(dirEntries) == 0 || sp.ForceDeleteSourcePath {
		os.RemoveAll(sourcePath)
	}
	
	// 再删除电视剧文件夹
	if mediaFile.PathId != "" {
		// ❌ 缺少 hasSeason 检查
		// 直接检查目录是否为空
		if len(dirEntries) == 0 || sp.ForceDeleteSourcePath {
			os.RemoveAll(mediaFile.TvshowPathId)
		}
	}
}
```

**问题2：删除顺序和时机问题**

- 当前逻辑是：先删除 Season 文件夹，再删除电视剧主文件夹
- 但是，对于每个视频文件，都会调用一次 `RemoveMediaSourcePath`
- 在第一次调用时，Season 1 文件夹被删除，但电视剧主文件夹下还有 Season 2 文件夹，所以不删除电视剧主文件夹
- 在第二次调用时，Season 2 文件夹被删除，但此时应该检查并删除电视剧主文件夹
- **但是**，如果没有 `hasSeason` 检查，可能会在还有其他 Season 文件夹时就尝试删除电视剧主文件夹，导致逻辑混乱

**问题3：`ForceDeleteSourcePath` 的语义不清晰**

- `ForceDeleteSourcePath = true` 意味着"强制删除源路径，即使不为空"
- 但是在多层文件夹结构下，应该如何处理？
  - 选项1：递归删除所有空文件夹（从最深层开始，逐层向上）
  - 选项2：只删除最底层的文件夹（Season 文件夹），不删除父文件夹
- 当前实现似乎是想实现选项1，但逻辑不完整

**问题4：缺少详细日志**

- 删除决策过程缺少详细日志
- 无法确定是否真的尝试删除了 Season 文件夹
- 无法确定删除是否成功

## 数据库更改

### 无需数据库结构更改

`ScrapePath` 表已经有 `ForceDeleteSourcePath` 字段，无需修改。

## 前端更改

### 无需前端更改

前端已经正确实现了"删除整理完的非空路径"开关，无需修改。

## 实现方案

### 阶段1：修复本地文件系统的删除逻辑

**目标**：确保正确删除 Season 文件夹和电视剧主文件夹

**修改文件**：`internal/scrape/rename/rename_local.go`

**修改内容**：

```go
func (r *RenameLocal) RemoveMediaSourcePath(mediaFile *models.ScrapeMediaFile, sp *models.ScrapePath) error {
	hasSeason := true
	sourcePath := mediaFile.PathId
	if sourcePath == "" && mediaFile.MediaType == models.MediaTypeTvShow {
		sourcePath = mediaFile.TvshowPathId
		hasSeason = false
	}
	
	if sourcePath == sp.SourcePath {
		helpers.AppLogger.Info("视频文件的父目录是来源根路径，不删除")
		return nil
	}
	
	// 判断这个目录下是否没有任何其他文件或目录
	dirEntries, _ := os.ReadDir(sourcePath)
	if len(dirEntries) > 0 {
		// 检查目录下是否有其他视频文件，如果有则跳过
		for _, entry := range dirEntries {
			if sp.IsVideoFile(entry.Name()) {
				helpers.AppLogger.Infof("目录 %s 下有其他视频文件，不删除", sourcePath)
				return nil
			}
		}
	}
	
	// 删除 Season 文件夹（或电影的媒体文件夹）
	if len(dirEntries) == 0 || sp.ForceDeleteSourcePath {
		err := os.RemoveAll(sourcePath)
		if err != nil {
			helpers.AppLogger.Errorf("删除本地目录失败: %s %v", sourcePath, err)
			return err
		}
		helpers.AppLogger.Infof("刮削完成，尝试删除本地目录成功, 路径：%s", sourcePath)
	}
	
	// 如果有 Season 文件夹，再尝试删除电视剧主文件夹
	if mediaFile.PathId != "" && hasSeason {
		// 检查电视剧文件夹的父目录是否是来源根路径
		if mediaFile.TvshowPathId == sp.SourcePathId {
			helpers.AppLogger.Info("电视剧的父目录是来源根路径，不删除")
			return nil
		}
		
		// 检查电视剧主文件夹下是否还有其他目录（其他 Season 文件夹）
		tvshowDirEntries, _ := os.ReadDir(mediaFile.TvshowPathId)
		if len(tvshowDirEntries) > 0 {
			for _, entry := range tvshowDirEntries {
				if entry.IsDir() {
					helpers.AppLogger.Infof("电视剧目录 %s 下还有其他目录 %s，不删除电视剧主文件夹", mediaFile.TvshowPathId, entry.Name())
					return nil
				}
			}
		}
		
		// 删除电视剧主文件夹
		if len(tvshowDirEntries) == 0 || sp.ForceDeleteSourcePath {
			err := os.RemoveAll(mediaFile.TvshowPathId)
			if err != nil {
				helpers.AppLogger.Errorf("删除电视剧文件夹失败: %s %v", mediaFile.TvshowPathId, err)
				return err
			}
			helpers.AppLogger.Infof("刮削完成，尝试删除本地电视剧文件夹成功, 路径：%s", mediaFile.TvshowPathId)
		}
	}
	
	return nil
}
```

### 阶段2：修复百度网盘的删除逻辑

**修改文件**：`internal/scrape/rename/rename_baidupan.go`

**修改内容**：与本地文件系统类似的修改，添加 `hasSeason` 检查逻辑。

### 阶段3：修复 openlist 的删除逻辑

**修改文件**：`internal/scrape/rename/rename_openlist.go`

**修改内容**：与本地文件系统类似的修改，添加 `hasSeason` 检查逻辑。

### 阶段4：增强日志记录

**目标**：添加详细的日志，记录删除决策过程

**修改内容**：
- 在删除 Season 文件夹前，记录是否找到 Season 文件夹
- 在删除电视剧主文件夹前，记录是否还有其他 Season 文件夹
- 在删除成功或失败后，记录详细的结果

## 测试计划

### 单元测试

1. **测试 `RemoveMediaSourcePath` 函数**：
   - 测试单层文件夹结构（电影）
   - 测试两层文件夹结构（电视剧 + Season）
   - 测试多层文件夹结构（电视剧 + 多个 Season）
   - 测试 `ForceDeleteSourcePath = true` 和 `false` 的情况

### 集成测试

1. **测试完整的刮削和整理流程**：
   - 准备具有两层文件夹结构的剧集文件
   - 开启"删除整理完的非空路径"
   - 执行刮削和整理
   - 验证 Season 文件夹是否被删除
   - 验证电视剧主文件夹是否被删除

2. **测试部分 Season 整理的情况**：
   - 准备具有多个 Season 的剧集文件
   - 只整理部分 Season
   - 验证未整理的 Season 文件夹是否保留
   - 验证电视剧主文件夹是否保留（因为还有未整理的 Season）

### 端到端测试

1. **测试用户操作流程**：
   - 在刮削目录设置中，开启"删除整理完的非空路径"
   - 准备具有两层文件夹结构的剧集文件
   - 执行刮削和整理
   - 检查原路径的文件夹结构
   - 验证所有空文件夹都被删除

## 风险评估

### 低风险

- **代码修改范围明确**：只修改删除逻辑，不影响其他功能
- **向后兼容**：不影响现有功能
- **可回滚**：如果出现问题，可以快速回滚代码

### 中等风险

- **删除逻辑复杂**：多层文件夹结构的删除逻辑比较复杂，需要仔细测试
- **并发问题**：多个视频文件同时整理时，可能会有并发删除的问题

### 风险缓解措施

1. **详细日志**：记录所有删除操作的详细日志，便于排查问题
2. **逐步推出**：先在测试环境验证，再推广到生产环境
3. **用户确认**：在删除前，确保文件夹真的是空的

## 预期结果

修复后，"删除整理完的非空路径"功能将正确工作：
- Season 文件夹在整理完成后会被正确删除
- 电视剧主文件夹在所有 Season 都整理完成后会被删除
- 用户不再需要手动删除空的 Season 文件夹
