### PR TITLE
Issue #199: 修复文件整理通用变量 original_title 和 original_name 无效

### DIFF
--- a/internal/models/scrapemedia.go
+++ b/internal/models/scrapemedia.go
@@ -590,12 +590,13 @@ func (sm *ScrapeMediaFile) isNewTemplateSyntax(template string) bool {
 
 func (sm *ScrapeMediaFile) buildTemplateContext() pongo2.Context {
 	ctx := pongo2.Context{
-		"title":       sm.Name,
-		"year":        sm.Year,
-		"tmdbid":      sm.TmdbId,
-		"videoFormat": sm.Resolution,
-		"edition":     sm.ResolutionLevel,
-		"fileExt":     sm.VideoExt,
+		"title":         sm.Name,
+		"year":          sm.Year,
+		"tmdbid":        sm.TmdbId,
+		"videoFormat":   sm.Resolution,
+		"edition":       sm.ResolutionLevel,
+		"fileExt":       sm.VideoExt,
+		"original_name": sm.VideoFilename,
 	}
 
 	if sm.Media != nil {
@@ -701,6 +702,18 @@ func (sm *ScrapeMediaFile) GenerateNameByTemplate(template string) string {
 		newName = strings.ReplaceAll(newName, "{tmdb_id}", fmt.Sprintf("{tmdbid-%d}", sm.TmdbId))
 	} else {
 		newName = strings.ReplaceAll(newName, "{tmdb_id}", "")
+	}
+	// 处理 original_title（原始标题）
+	if sm.Media != nil && sm.Media.OriginalName != "" {
+		newName = strings.ReplaceAll(newName, "{original_title}", sm.Media.OriginalName)
+	} else {
+		newName = strings.ReplaceAll(newName, "{original_title}", "")
+	}
+	// 处理 original_name（原始文件名）
+	if sm.VideoFilename != "" {
+		newName = strings.ReplaceAll(newName, "{original_name}", sm.VideoFilename)
+	} else {
+		newName = strings.ReplaceAll(newName, "{original_name}", "")
 	}
 	// 处理演员
 	actorName := ""


### PR DESCRIPTION
# 开发文档 - Issue #199

## 需求概述

修复文件整理通用变量 `original_title` 和 `original_name` 无法正常输出的问题。

## 技术分析

### 问题根因

1. **`original_title`**：
   - 只在新模板语法（pongo2）的 `buildTemplateContext` 函数中定义
   - 旧模板语法（使用 `{original_title}`）的 `GenerateNameByTemplate` 函数没有处理这个变量

2. **`original_name`**：
   - 根本没有在任何地方映射为模板变量
   - 应该映射到 `ScrapeMediaFile.VideoFilename`（原始文件名）

### 代码位置

- `internal/models/scrapemedia.go`
  - `buildTemplateContext()` 函数（约602行）：新模板语法的变量定义
  - `GenerateNameByTemplate()` 函数（约674行）：旧模板语法的变量替换

## 数据库更改

无

## 前端更改

无

## 实现方案

### 阶段1：修复旧模板语法中的 `original_title` 变量

在 `GenerateNameByTemplate` 函数中添加 `{original_title}` 的处理逻辑：

```go
// 处理 original_title（原始标题）
if sm.Media != nil && sm.Media.OriginalName != "" {
    newName = strings.ReplaceAll(newName, "{original_title}", sm.Media.OriginalName)
} else {
    newName = strings.ReplaceAll(newName, "{original_title}", "")
}
```

### 阶段2：添加 `original_name` 变量支持

1. 在 `buildTemplateContext` 函数中添加 `original_name` 映射：

```go
ctx["original_name"] = sm.VideoFilename
```

2. 在 `GenerateNameByTemplate` 函数中添加 `{original_name}` 的处理逻辑：

```go
// 处理 original_name（原始文件名）
if sm.VideoFilename != "" {
    newName = strings.ReplaceAll(newName, "{original_name}", sm.VideoFilename)
} else {
    newName = strings.ReplaceAll(newName, "{original_name}", "")
}
```

### 变量说明

| 变量名 | 数据来源 | 说明 |
|--------|----------|------|
| `original_title` | `sm.Media.OriginalName` | TMDB 原始标题（如英文标题） |
| `original_name` | `sm.VideoFilename` | 原始文件名 |

## 测试计划

### 单元测试

无（变量替换逻辑较为简单，不需要新增单元测试）

### 集成测试

1. **旧模板语法测试**：
   - 使用模板 `{title} ({year}) [{original_title}]` 整理电影
   - 使用模板 `{title} ({year}) - {original_name}` 整理电影
   - 验证变量被正确替换

2. **新模板语法测试**：
   - 使用模板 `{{ title }} ({{ year }}) {% if original_title %}[{{ original_title }}]{% endif %}` 整理电影
   - 使用模板 `{{ title }} ({{ year }}) - {{ original_name }}` 整理电影
   - 验证变量被正确替换

3. **空值处理测试**：
   - 测试 `original_title` 为空时的处理
   - 测试 `original_name` 为空时的处理

### 端到端测试

无（由用户进行实际测试）

## 风险评估

- **风险等级**：低
- **影响范围**：仅影响文件整理模板变量替换逻辑
- **回滚方案**：如果出现问题，可以快速回滚到之前的代码

## 相关链接

- **Issue**: https://github.com/qicfan/qmediasync/issues/199
- **相关Issue**: https://github.com/qicfan/qmediasync/issues/171（原始添加变量的Issue）