### PR TITLE
Issue #203: 修复生成STRM时提示path_id和path参数不能为空

### DIFF
--- a/internal/controllers/sync.go
+++ b/internal/controllers/sync.go
@@ -682,8 +682,8 @@ func ManualSync(c *gin.Context) {
 		c.JSON(http.StatusOK, APIResponse[any]{Code: BadRequest, Message: fmt.Sprintf("请求参数错误: %v", err), Data: nil})
 		return
 	}
-	if req.PathId == "" || req.Path == "" {
-		c.JSON(http.StatusOK, APIResponse[any]{Code: BadRequest, Message: "path_id 和 path 参数不能为空", Data: nil})
+	if req.PathId == "" {
+		c.JSON(http.StatusOK, APIResponse[any]{Code: BadRequest, Message: "path_id 参数不能为空", Data: nil})
 		return
 	}
 	account, err := models.GetAccountById(req.AccountId)


### PR DESCRIPTION
# 开发文档 - Issue #203

## 需求概述

修复手动触发STRM同步任务时，接口返回错误 "path_id 和 path 参数不能为空" 的问题。

## 技术分析

### 问题描述

- **错误信息**：`path_id 和 path 参数不能为空`
- **触发场景**：在文件管理器中选择文件后，点击"生成STRM"按钮
- **影响**：无法生成STRM文件

### 问题根因

#### 前端代码 (`AppFileManager.vue:642`)

```javascript
const response = await http?.post(`${SERVER_URL}/sync/manual`, {
  path_id: strmSourceItem.value.id,
  // path: itemPath,   <-- 被注释掉了！
  target_path: strmTargetDir.value.path,
  // is_file: !strmSourceItem.value.is_directory,   <-- 也被注释掉了！
  account_id: selectedAccountId.value,
})
```

前端没有传递 `path` 和 `is_file` 参数。

#### 后端代码 (`internal/controllers/sync.go:680-682`)

```go
if req.PathId == "" || req.Path == "" {
    c.JSON(http.StatusOK, APIResponse[any]{Code: BadRequest, Message: "path_id 和 path 参数不能为空", Data: nil})
    return
}
```

后端检查 `path` 不能为空，但第687行之后有处理 `path` 为空的逻辑：

```go
if req.Path == "" {
    // 使用文件ID查询详情
    switch account.SourceType {
    case models.SourceType115:
        client := account.Get115Client()
        fileDetail, err := client.GetFsDetailByCid(context.Background(), req.PathId)
        ...
        req.Path = fileDetail.Path
        req.IsFile = fileDetail.IsDir == 0
    ...
    }
}
```

### 问题分析

1. 后端代码逻辑冲突：
   - 第680-682行要求 `path` 不能为空
   - 第687行之后有处理 `path` 为空的逻辑
2. 前端注释掉了 `path` 和 `is_file` 参数，可能是为了简化调用

### 修复方案

**方案**：修改后端逻辑，允许 `path` 为空，当 `path` 为空时通过 `path_id` 查询文件详情获取路径。

**修改内容**：
1. 移除第680-682行对 `path` 的非空检查
2. 只保留 `path_id` 的非空检查

## 数据库更改

无

## 前端更改

无（前端代码被注释掉是故意的，让后端自动获取路径）

## 实现方案

### 阶段1：修改后端验证逻辑

修改 `internal/controllers/sync.go` 中的 `ManualSync` 函数：

**修改前**：
```go
if req.PathId == "" || req.Path == "" {
    c.JSON(http.StatusOK, APIResponse[any]{Code: BadRequest, Message: "path_id 和 path 参数不能为空", Data: nil})
    return
}
```

**修改后**：
```go
if req.PathId == "" {
    c.JSON(http.StatusOK, APIResponse[any]{Code: BadRequest, Message: "path_id 参数不能为空", Data: nil})
    return
}
```

## 测试计划

### 单元测试

无

### 集成测试

1. 测试只传递 `path_id`，不传递 `path`，验证能正常生成STRM
2. 测试同时传递 `path_id` 和 `path`，验证能正常生成STRM
3. 测试不传递 `path_id`，验证返回错误

### 端到端测试

1. 在文件管理器中选择文件，点击"生成STRM"
2. 选择目标目录，确认生成
3. 验证STRM文件生成成功

## 风险评估

- **风险等级**：低
- **影响范围**：仅影响手动触发STRM同步功能
- **回滚方案**：恢复原有的参数检查逻辑

## 相关链接

- **Issue**: https://github.com/qicfan/qmediasync/issues/203