### PR TITLE
Issue #209: [Bug] v0.14.20 刮削重命名时数组越界panic

### DIFF
--- a/internal/scrape/category_movie.go
+++ b/internal/scrape/category_movie.go
@@ -26,6 +26,10 @@ func (cm *CategoryMovieImpl) DoCategory(mediaFile *models.ScrapeMediaFile) (stri
 	genres := mediaFile.Media.Genres
 	originalLanguage := mediaFile.Media.OriginalLanguage
 	helpers.AppLogger.Infof("计算电影的二级分类，影片名称: %s 流派 %+v 和语言 %s", mediaFile.Media.Name, genres, originalLanguage)
+	if len(cm.scrapePath.Category.MovieCategory) == 0 {
+		helpers.AppLogger.Warnf("电影分类规则为空，跳过分类")
+		return "", nil
+	}
 	defaultCategory := cm.scrapePath.Category.MovieCategory[0]
 	if len(genres) == 0 && originalLanguage != "" {
 		helpers.AppLogger.Infof("只有语言 %s 要求，不匹配流派", originalLanguage)

--- a/internal/scrape/category_tvshow.go
+++ b/internal/scrape/category_tvshow.go
@@ -26,6 +26,10 @@ func (ct *CategoryTvShowImpl) DoCategory(mediaFile *models.ScrapeMediaFile) (str
 	genres := mediaFile.Media.Genres
 	originalCountry := mediaFile.Media.OriginCountry
 	helpers.AppLogger.Infof("计算电视剧的二级分类，影片名称: %s 流派 %+v 和国家 %+v 的二级分类", mediaFile.Media.Name, genres, originalCountry)
+	if len(ct.scrapePath.Category.TvShowCategory) == 0 {
+		helpers.AppLogger.Warnf("电视剧分类规则为空，跳过分类")
+		return "", nil
+	}
 	defaultCategory := ct.scrapePath.Category.TvShowCategory[0]
 	if len(genres) == 0 && len(originalCountry) > 0 {
 		helpers.AppLogger.Infof("电视剧只有国家 %+v 要求，没有流派", originalCountry)

--- a/internal/scrape/tmdb_movie.go
+++ b/internal/scrape/tmdb_movie.go
@@ -33,7 +33,7 @@ func (t *TmdbMovieImpl) CheckByNameAndYear(name string, year int, switchYear boo
 		helpers.AppLogger.Errorf("查询tmdb电影详情失败, 下次重试, 失败原因: %v", err)
 		return "", 0, 0, err
 	}
-	if movieDetail != nil && movieDetail.TotalResults > 0 {
+	if movieDetail != nil && movieDetail.TotalResults > 0 && len(movieDetail.Results) > 0 {
 		if movieDetail.TotalResults > 1 {
 			// 如果第一个数据的title等于name则认为是正确的
 			if strings.EqualFold(movieDetail.Results[0].Title, name) || strings.EqualFold(movieDetail.Results[0].OriginalTitle, name) {


### PR DESCRIPTION
## 修复内容

### 问题根因
刮削重命名时数组越界 panic (`index out of range [0] with length 0`)，导致主进程崩溃。

**根因**：
1. `category_movie.go:29` 和 `category_tvshow.go:29` 中直接访问 `MovieCategory[0]` / `TvShowCategory[0]` 作为默认分类，当用户启用二级分类但未配置任何分类规则时，数组为空导致 panic
2. `tmdb_movie.go` 中依赖 `TotalResults > 0` 判断而不检查 `len(Results)`，TMDB API 可能返回不一致数据

### 修复方案
1. `DoCategory()` 函数开头添加 `len(MovieCategory/TvShowCategory) == 0` 检查，空数组时记录警告日志并安全返回 nil（跳过分类，不中断刮削流程）
2. `tmdb_movie.go` 添加 `len(movieDetail.Results) > 0` 双重保护

### 修改文件
- `internal/scrape/category_movie.go` - 添加长度检查
- `internal/scrape/category_tvshow.go` - 添加长度检查
- `internal/scrape/tmdb_movie.go` - 添加双重检查

### 测试
- ✅ gofmt 格式化检查
- ✅ go vet 语法检查
- ✅ go build 编译检查
- ✅ 单元测试通过