### PR TITLE
Issue #217: Emby媒体库同步选择列表存在已删除的媒体库和重复选项

### DIFF
--- a/internal/controllers/emby_sync.go
+++ b/internal/controllers/emby_sync.go
@@ -105,6 +105,15 @@ func GetEmbyLibraries(c *gin.Context) {
 		return
 	}
 
+	// 清理已不在Emby中存在的媒体库记录
+	activeLibraryIds := make([]string, 0, len(libs))
+	for _, lib := range libs {
+		activeLibraryIds = append(activeLibraryIds, lib.ID)
+	}
+	if err := models.CleanupDeletedEmbyLibraries(activeLibraryIds); err != nil {
+		helpers.AppLogger.Warnf("清理已删除媒体库记录失败: %v", err)
+	}
+
 	libraries, err := models.GetAllEmbyLibraries()
 	if err != nil {
 		c.JSON(http.StatusOK, APIResponse[any]{Code: BadRequest, Message: "获取媒体库列表失败: " + err.Error()})

--- a/internal/models/emby_media.go
+++ b/internal/models/emby_media.go
@@ -109,6 +109,21 @@ func UpsertEmbyLibraries(libs []embyclientrestgo.EmbyLibrary) error {
 	return nil
 }
 
+// CleanupDeletedEmbyLibraries 清理已不在Emby中存在的媒体库记录
+func CleanupDeletedEmbyLibraries(activeLibraryIds []string) error {
+	if len(activeLibraryIds) == 0 {
+		return nil
+	}
+
+	// 级联清理关联的同步路径记录
+	if err := db.Db.Where("library_id NOT IN ?", activeLibraryIds).Delete(&EmbyLibrarySyncPath{}).Error; err != nil {
+		return err
+	}
+
+	// 清理已删除的媒体库记录
+	return db.Db.Where("library_id NOT IN ?", activeLibraryIds).Delete(&EmbyLibrary{}).Error
+}
+
 // CreateOrUpdateEmbyMediaItem upsert by ItemId
 func CreateOrUpdateEmbyMediaItem(item *EmbyMediaItem) error {
 	existing := &EmbyMediaItem{}


### PR DESCRIPTION
# 开发文档 - Issue #217

## 需求概述
Emby媒体库同步选择页面的下拉列表中，存在已在Emby后台删除的无效媒体库和重复选项。

## 技术分析

### 问题根因
1. `UpsertEmbyLibraries()` 只做 upsert（创建/更新），不删除 Emby 中已删除的媒体库记录
2. `GetAllEmbyLibraries()` 从数据库读取全部记录，包含过期数据
3. `GetEmbyLibraries` API 先调 Emby API 拿最新列表并 upsert，再从数据库读，但没有清理旧记录

### 数据流
1. 前端 `loadEmbyLibraries()` → GET `/emby/libraries`
2. 后端 `GetEmbyLibraries()` → `client.GetAllMediaLibraries()` (从Emby实时获取) → `UpsertEmbyLibraries()` (写入数据库) → `GetAllEmbyLibraries()` (从数据库读)
3. 问题：Emby删除了媒体库A，但数据库中仍保留A的记录，Upsert不会删除

## 数据库更改
无

## 前端更改
无

## 实现方案

### 修改文件
`internal/controllers/emby_sync.go` - `GetEmbyLibraries()` 函数

### 实现内容
在 `UpsertEmbyLibraries()` 之后、`GetAllEmbyLibraries()` 之前，添加清理逻辑：
- 获取 Emby 返回的媒体库 ID 列表
- 删除数据库中不在该列表中的记录（即已被 Emby 删除的媒体库）

### 新增函数
`internal/models/emby_media.go` - `CleanupDeletedEmbyLibraries(activeLibraryIds []string)` 
- 删除 `emby_libraries` 表中 `library_id` 不在 `activeLibraryIds` 列表中的记录
- 使用 `WHERE library_id NOT IN (...)` 批量删除

## 测试计划
- go fmt 检查
- go vet 检查
- go build 编译检查
- 单元测试

## 风险评估
低风险。仅删除已不存在的媒体库记录。但需注意：如果关联了 `emby_library_sync_paths`，需级联处理或检查外键约束。