### PR TITLE
Issue #229: Gitee更新渠道版本列表排序和时间显示错误

### DIFF
--- a/internal/updater/gitee_updater.go
+++ b/internal/updater/gitee_updater.go
@@ -14,30 +14,30 @@ import (
 )
 
 type GiteeRelease struct {
-	ID          int64       `json:"id"`
-	TagName     string      `json:"tag_name"`
-	Name        string      `json:"name"`
-	Body        string      `json:"body"`
-	Draft       bool        `json:"draft"`
-	Prerelease  bool        `json:"prerelease"`
-	PublishedAt string      `json:"published_at"`
+	ID          int64        `json:"id"`
+	TagName     string       `json:"tag_name"`
+	Name        string       `json:"name"`
+	Body        string       `json:"body"`
+	Draft       bool         `json:"draft"`
+	Prerelease  bool         `json:"prerelease"`
+	PublishedAt string       `json:"created_at"`
 	Assets      []GiteeAsset `json:"assets"`
-	HTMLURL     string      `json:"html_url"`
+	HTMLURL     string       `json:"html_url"`
 }
 
 type GiteeAsset struct {
-	ID               int64  `json:"id"`
-	Name             string `json:"name"`
+	ID                 int64  `json:"id"`
+	Name               string `json:"name"`
 	BrowserDownloadURL string `json:"browser_download_url"`
-	Size             int64  `json:"size"`
-	ContentType      string `json:"content_type"`
+	Size               int64  `json:"size"`
+	ContentType        string `json:"content_type"`
 }
 
 type GiteeUpdater struct {
-	Owner          string
-	Repo           string
-	CurrentVersion string
-	HTTPClient     *http.Client
+	Owner             string
+	Repo              string
+	CurrentVersion    string
+	HTTPClient        *http.Client
 	IncludePreRelease bool
 }
 


### PR DESCRIPTION
### 修复内容

**根因**：Gitee API v5 的 releases 接口不返回 `published_at` 字段，只返回 `created_at` 字段。代码中 `GiteeRelease.PublishedAt` 的 JSON tag 映射到了不存在的 `published_at`，导致：
1. **排序错误**：`PublishedAt` 始终为空，排序时间全部为零值，结果不确定
2. **时间显示错误**：零值时间格式化后显示错误

**修复**：将 JSON tag 从 `json:"published_at"` 改为 `json:"created_at"`

**验证**：通过 curl 确认 Gitee API 实际返回 `created_at` 格式为 RFC3339（如 `2026-03-30T14:44:10+08:00`），兼容现有 `time.Parse(time.RFC3339, ...)` 解析逻辑。

**涉及文件**：
- `internal/updater/gitee_updater.go` — GiteeRelease 结构体 JSON tag 修改