### PR TITLE
Issue #234: 刮削错误手动回退后自动删除影片

### DIFF
--- a/internal/scrape/scrape_episode.go
+++ b/internal/scrape/scrape_episode.go
@@ -230,9 +230,10 @@ func (t *tvShowScrapeImpl) FinishEpisode(mediaFile *models.ScrapeMediaFile) {
 	// if mediaFile.SourceType == models.SourceTypeLocal {
 	// 	t.RemoveEpisodeTmpFiles(mediaFile)
 	// }
-	if mediaFile.ScrapeType == models.ScrapeTypeOnly || mediaFile.RenameType != models.RenameTypeMove {
+	if mediaFile.ScrapeType == models.ScrapeTypeOnly || mediaFile.RenameType != models.RenameTypeMove || mediaFile.IsReScrape {
 		// 如果仅刮削，跳过
 		// 如果不是移动模式，跳过
+		// 如果是重新刮削（回退后），跳过删除源路径
 		// 如果不强制删除来源目录，跳过
 		// 如果视频在来源根目录，跳过
 		helpers.AppLogger.Infof("视频 %s 存在不符合删除来源目录的条件，跳过删除来源目录: %s", mediaFile.Name, mediaFile.Path)

--- a/internal/scrape/scrape_movie.go
+++ b/internal/scrape/scrape_movie.go
@@ -527,9 +527,10 @@ func (m *movieScrapeImpl) FinishMovie(mediaFile *models.ScrapeMediaFile) {
 			}
 		}
 	}
-	if mediaFile.ScrapeType == models.ScrapeTypeOnly || mediaFile.RenameType != models.RenameTypeMove {
+	if mediaFile.ScrapeType == models.ScrapeTypeOnly || mediaFile.RenameType != models.RenameTypeMove || mediaFile.IsReScrape {
 		// 如果仅刮削，跳过
 		// 如果不是移动模式，跳过
+		// 如果是重新刮削（回退后），跳过删除源路径
 		// 如果不强制删除来源目录，跳过
 		// 如果视频在来源根目录，跳过
 		helpers.AppLogger.Infof("视频 %s 存在不符合删除来源目录的条件，跳过删除来源目录: %s", mediaFile.Name, mediaFile.Path)


### PR DESCRIPTION
## 问题根因

回退后重新刮削时，虽然  字段已设置为 true，但  和  没有检查该字段，仍然执行  删除源路径。

## 修复方案

在  和  中添加  检查：
- 如果是重新刮削（回退后），跳过 

## 修改文件

- : 在  中添加  检查
- : 在  中添加  检查